### PR TITLE
add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# changelog
+
+## [unreleased]
+
+## [0.4.0] - 2026-02-16
+
+- add skills and subagents
+- add SBOM generation for releases
+
+## [0.3.1] - 2026-01-30
+
+- add auto mode
+- change argument order for `invoke`
+
+## [0.3.0] - 2026-01-29
+
+- add dry run mode
+- add snippets
+
+## [0.2.1] - 2026-01-29
+
+- add bandit to dev dependencies
+- rename profiles to conjurings consistently throughout
+
+## [0.2.0] - 2026-01-24
+
+- add worktree support for `invoke` (fixes #10)
+
+## [0.1.2] - 2026-01-20
+
+- refactor agent definitions
+- add initial SLP version of conjurings and invocations (#9)
+
+## [0.1.1] - 2026-01-19
+
+- minor consistency fixes
+
+## [0.1.0] - 2026-01-19
+
+- first stable release
+
+## [0.0.5] - 2026-01-19
+
+- improve invocations and conjurings
+- minor cleanups
+
+## [0.0.4] - 2026-01-19
+
+- add `lint`, `simplify`, `read` subcommands
+- add tests for lint CLI
+
+## [0.0.3] - 2026-01-18
+
+- add `conjurings` subcommand (fixes #5)
+- add better error messages and debug output (closes #2, #7)
+
+## [0.0.2] - 2026-01-18
+
+- add `list` command (closes #3)
+- add test suite (closes #1)
+- drop python 3.9 support
+
+## [0.0.1] - 2026-01-16
+
+- initial release


### PR DESCRIPTION
## What

Adds a CHANGELOG.md covering all releases from v0.0.1 through v0.4.0, reconstructed from git tag history and commit messages.

## Why

familiar has 13 published versions but no changelog. A changelog makes it easier for users to understand what changed between versions without digging through git history.

Follows the lowercase, terse format used by other cyberwitchery changelogs (alembic, netform, sbom-diff, etc.).

---
_Opened by the cyberwitchery heartbeat agent (Claude). Veit has not reviewed this yet._